### PR TITLE
Expected code block content ignores language type

### DIFF
--- a/t/08_create_helpers.t
+++ b/t/08_create_helpers.t
@@ -94,7 +94,7 @@ my $expected_html = <<EOF;
 <li>Item 1</li>
 <li>Item 2</li>
 </ol>
-<pre><code>Code block</code></pre>
+<pre><code class="language-perl">Code block</code></pre>
 <div>html</html>
 <hr />
 <p><em>emph</em>


### PR DESCRIPTION
I tried to install CommonMark-0.230002 from CPAN using cmark [4e9abf79](https://github.com/jgm/cmark/tree/4e9abf792a151dca99cc9c637d5fae681b693997). `nmake test` failed with:

```
not ok 2 - create_* helpers

#   Failed test 'create_* helpers'
#   at t/08_create_helpers.t line 104.
#          got: '<h2>Header</h2>
# <blockquote>
# <p>Block quote</p>
# </blockquote>
# <ol start="2">
# <li>Item 1</li>
# <li>Item 2</li>
# </ol>
# <pre><code class="language-perl">Code block</code></pre>
# <div>html</html>
# <hr />
# <p><em>emph</em>
# <a href="/url" title="link title"><strong>link text</strong></a><br />
# <img src="/facepalm.jpg" alt="alt text" title="image title" /></p>
# '
#     expected: '<h2>Header</h2>
# <blockquote>
# <p>Block quote</p>
# </blockquote>
# <ol start="2">
# <li>Item 1</li>
# <li>Item 2</li>
# </ol>
# <pre><code>Code block</code></pre>
# <div>html</html>
# <hr />
# <p><em>emph</em>
# <a href="/url" title="link title"><strong>link text</strong></aTH><br />
# <img src="/facepalm.jpg" alt="alt text" title="image title" /></p>
# '
# Looks like you failed 1 test of 2.
Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/2 subtests

Test Summary Report
-------------------
t/08_create_helpers.t (Wstat: 256 Tests: 2 Failed: 1)
  Failed test:  2
  Non-zero exit status: 1
```

Clearly, the expected HTML does not include the `class="language-perl"` attribute which is set in the test code on [line 50](https://github.com/nwellnhof/perl-commonmark/blob/master/t/08_create_helpers.t#L50):

```
    CommonMark->create_code_block(
        fence_info => 'perl',
        literal    => 'Code block',
    ),
```
