### PR TITLE
Accommodate WinSDK 7.1 VC compiler

### DIFF
--- a/CommonMark.xs
+++ b/CommonMark.xs
@@ -172,6 +172,7 @@ MODULE = CommonMark  PACKAGE = CommonMark  PREFIX = cmark_
 PROTOTYPES: DISABLE
 
 BOOT:
+    { /* new scope to accommodate WinSDK 7.1 VC compiler */
     static const struct {
         const char *name;
         int value;
@@ -245,6 +246,7 @@ BOOT:
     for (i = 0; i < num_constants; i++) {
         newCONSTSUB(stash, constants[i].name, newSViv(constants[i].value));
     }
+    } /* accommodate WinSDK 7.1 VC compiler */
 
 char*
 cmark_markdown_to_html(package, string, options = 0)


### PR DESCRIPTION
Enclose `BOOT` code in a block to prevent compiler errors.

On

<pre>Microsoft Windows [Version 6.0.6002] (Vista SP2 x86)
cl version  16.00.40219.01 for 80x86
perl 5, version 23, subversion 7 (v5.23.7) built for MSWin32-x86-multi-thread-64int</pre>


Fixes:

```
        cl -c    -nologo -GF -W3 -O1 -arch:SSE2 -GF -MD -Zi -DNDEBUG -GL -DWIN32 -D_CONSOLE -DNO_STRICT -D_CRT_SECURE_NO_DEPRECATE -
D_CRT_NONSTDC_NO_DEPRECATE -DPERL_TEXTMODE_SCRIPTS -DPERL_IMPLICIT_CONTEXT -DPERL_IMPLICIT_SYS -DWIN32_NO_REGISTRY -O1 -arch:SSE2 -GF -MD -Zi -DNDEBUG -GL    -DVERSION=\"0.240100\"  -DXS_VERSION=\"0.240100\"  "-IC:\opt\perl\5.23.7\lib\CORE"   CommonMark.c
CommonMark.c
CommonMark.xs(175) : error C2143: syntax error : missing ';' before '<class-head>'
CommonMark.xs(177) : error C2143: syntax error : missing ';' before 'type'
CommonMark.xs(179) : warning C4047: 'initializing' : 'int' differs in levels of indirection from 'char [10]'
CommonMark.xs(179) : error C2078: too many initializers
CommonMark.xs(180) : warning C4047: 'initializing' : 'int' differs in levels of indirection from 'char [14]'
CommonMark.xs(181) : warning C4047: 'initializing' : 'int' differs in levels of indirection from 'char [17]'
. . . <snip> . . .
CommonMark.xs(238) : error C2065: 'my_perl' : undeclared identifier
CommonMark.xs(238) : warning C4047: 'function' : 'PerlInterpreter *' differs in levels of indirection from 'int'
CommonMark.xs(238) : warning C4024: 'Perl_gv_stashpv' : different types for formal and actual parameter 1
CommonMark.xs(238) : error C2099: initializer is not a constant
CommonMark.xs(240) : error C2059: syntax error : 'if'
CommonMark.xs(245) : error C2059: syntax error : 'for'
CommonMark.xs(245) : error C2143: syntax error : missing '{' before '<'
CommonMark.xs(245) : error C2059: syntax error : '<'
CommonMark.xs(245) : error C2143: syntax error : missing '{' before '++'
CommonMark.xs(245) : error C2059: syntax error : '++'
CommonMark.xs(245) : error C2059: syntax error : ')'
CommonMark.c(1419) : error C2371: 'Perl_xs_boot_epilog' : redefinition; different basic types
        c:\opt\perl\5.23.7\lib\core\proto.h(3536) : see declaration of 'Perl_xs_boot_epilog'
CommonMark.c(1421) : error C2059: syntax error : '}'
NMAKE : fatal error U1077: '"c:\Program Files\Microsoft Visual Studio 10.0\VC\Bin\cl.EXE"' : return code '0x2'
Stop.
```
