### PR TITLE
Use Alien::cmark to find or build libcmark

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -18,7 +18,8 @@ copyright_holder = Nick Wellnhofer
 perl = 5.008
 
 [Prereqs / ConfigureRequires ]
-Devel::CheckLib = 0
+Alien::Base::Wrapper = 1.55
+Alien::cmark = 0
 
 [Prereqs / TestRequires]
 Test::More = 0
@@ -45,15 +46,6 @@ copy = MANIFEST
 copy = META.yml
 
 [MakeMaker::Awesome]
-WriteMakefile_arg = LIBS => '-lcmark'
-header = use Devel::CheckLib;
-header = {
-header =     local @ARGV = @ARGV;
-header =     unshift(@ARGV, ExtUtils::MakeMaker::_shellwords($ENV{PERL_MM_OPT} || ''))
-header =         if $ExtUtils::MakeMaker::VERSION >= 6.73_08;
-header =     check_lib(
-header =         header   => 'cmark.h',
-header =         function => 'return CMARK_VERSION >= 0x001500 ? 0 : 1;',
-header =     ) or warn('libcmark 0.21.0 or higher not found'), exit;
-header = }
-
+header = use Alien::Base::Wrapper qw(Alien::cmark !export);
+header = Alien::cmark->atleast_version('0.21.0') or warn('libcmark 0.21.0 or higher required'), exit;
+WriteMakefile_arg = Alien::Base::Wrapper->mm_args


### PR DESCRIPTION
The [Alien::Build](https://metacpan.org/pod/Alien::Build) system allows creating modules that provide an interface to link against the system version of a library if appropriate, or otherwise download and install the library into Perl sharedirs (share build).

I've released [Alien::cmark](https://metacpan.org/pod/Alien::cmark) which can provide libcmark in this way, so it could be used by this module instead of relying on the user to have installed libcmark and its headers, thus making `cpan CommonMark` "just work" for most users (provided they have a C compiler). It uses pkg-config to determine if there is an appropriate system version to use.

Currently, Alien::cmark requires a minimum libcmark version of 0.21.0 as does this module, but I included a version check for the generated Makefile.PL here as well (possible since Alien::Base 1.55). The share build will install the latest version as of the Alien::cmark release.