### PR TITLE
Add GitHub workflow

### DIFF
--- a/.github/bin/build.ps1
+++ b/.github/bin/build.ps1
@@ -1,0 +1,22 @@
+Param (
+  $VERSION
+)
+
+$BASENAME = "cmark-${VERSION}"
+$PREFIX = "$env:GITHUB_WORKSPACE/${BASENAME}"
+
+if (Test-Path "Makefile") {
+  make realclean
+}
+
+echo "Building ${BASENAME} in ${PREFIX}";
+C:\msys64\usr\bin\wget.exe -q "https://github.com/jgm/cmark/archive/${VERSION}.tar.gz"
+tar -zxf "${VERSION}.tar.gz"
+cd "${BASENAME}"
+nmake /nologo /f Makefile.nmake INSTALLDIR="${PREFIX}" install
+cd ..
+
+echo "Building and testing CommonMark"
+$env:PATH += ";${PREFIX}/bin"
+perl Makefile.PL INC="-I${PREFIX}/include" LIBS="-L${PREFIX}/lib -lcmark"
+make test TEST_VERBOSE=1

--- a/.github/bin/build.sh
+++ b/.github/bin/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# exit and report the failure if any command fails
+exit_trap () {
+  local lc="$BASH_COMMAND" rc=$?
+  echo "Command [$lc] exited with code [$rc]"
+}
+
+trap exit_trap EXIT
+set -ex
+
+VERSION=${CMARK_VERSION:=0.29.0}
+BASENAME="cmark-${VERSION}"
+PREFIX="${PWD}/${BASENAME}"
+
+[ -e Makefile ] && make realclean
+
+printf "Building %s in %s\n" "${BASENAME}" "${PREFIX}"
+curl -sL "https://github.com/jgm/cmark/archive/${VERSION}.tar.gz" | tar xz
+(cd "${BASENAME}" && make INSTALL_PREFIX="${PREFIX}" install)
+
+printf "Building and testing CommonMark\n"
+perl Makefile.PL INC=-I"${PREFIX}/include" LIBS=-L"${PREFIX}/lib -lcmark"
+make
+make test TEST_VERBOSE=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,127 @@
+name: ✅ CI
+on: [push, pull_request]
+jobs:
+  test:
+    strategy:
+      matrix:
+        os:
+          - { icon: 🐧, name: ubuntu  }
+          - { icon: 🍎, name: macos   }
+          - { icon: 🪟, name: windows }
+        perl: [ '5.38', '5.36', '5.34', '5.32', '5.30', '5.28', '5.26', '5.24', '5.22', '5.20', '5.18', '5.16', '5.14', '5.12', '5.10', '5.8' ]
+    name: 🐪 Perl ${{ matrix.perl }} on ${{ matrix.os.icon }}
+    runs-on: ${{ matrix.os.name }}-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Perl
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: ${{ matrix.perl }}
+
+      # CommonMark depends on Devel::CheckLib and Test::LeakTrace; install the
+      # latest EU::MM for consistent builds on on macOS as fixed here:
+      # https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/pull/403
+      - name: Install Dependencies
+        run: |
+          perl -V
+          cpanm -v --notest --no-man-pages Devel::CheckLib Test::LeakTrace ExtUtils::MakeMaker
+
+      - name: Add MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+        if: runner.os == 'Windows'
+
+      - name: Test With cmark-0.30.3
+        if: runner.os != 'Windows'
+        run: ./.github/bin/build.sh 0.30.3
+
+      - name: Windows Test With cmark-0.30.3
+        if: runner.os == 'Windows'
+        run: ./.github/bin/build.ps1 -VERSION 0.30.3
+
+      - name: Test With cmark-0.29.0
+        if: runner.os != 'Windows'
+        run: ./.github/bin/build.sh 0.29.0
+
+      - name: Windows Test With cmark-0.29.0
+        if: runner.os == 'Windows'
+        run: ./.github/bin/build.ps1 -VERSION 0.29.0
+
+      - name: Test With cmark-0.28.3
+        if: runner.os != 'Windows'
+        run: ./.github/bin/build.sh 0.28.3
+
+      - name: Windows Test With cmark-0.28.3
+        if: runner.os == 'Windows'
+        run: ./.github/bin/build.ps1 -VERSION 0.28.3
+
+      - name: Test With cmark-0.27.1
+        if: runner.os != 'Windows'
+        run: ./.github/bin/build.sh 0.27.1
+
+      - name: Windows Test With cmark-0.27.1
+        if: runner.os == 'Windows'
+        run: ./.github/bin/build.ps1 -VERSION 0.27.1
+
+      - name: Test With cmark-0.26.1
+        if: runner.os != 'Windows'
+        run: ./.github/bin/build.sh 0.26.1
+
+      - name: Windows Test With cmark-0.26.1
+        if: runner.os == 'Windows'
+        run: ./.github/bin/build.ps1 -VERSION 0.26.1
+
+      - name: Test With cmark-0.25.2
+        if: runner.os != 'Windows'
+        run: ./.github/bin/build.sh 0.25.2
+
+      - name: Windows Test With cmark-0.25.2
+        if: runner.os == 'Windows'
+        run: ./.github/bin/build.ps1 -VERSION 0.25.2
+
+      - name: Test With cmark-0.24.1
+        if: runner.os != 'Windows'
+        run: ./.github/bin/build.sh 0.24.1
+
+      - name: Windows Test With cmark-0.24.1
+        if: runner.os == 'Windows'
+        run: ./.github/bin/build.ps1 -VERSION 0.24.1
+
+      - name: Test With cmark-0.20.0
+        if: runner.os != 'Windows'
+        run: ./.github/bin/build.sh 0.20.0
+
+      - name: Windows Test With cmark-0.20.0
+        if: runner.os == 'Windows'
+        run: ./.github/bin/build.ps1 -VERSION 0.20.0
+
+  apt:
+    name: 📦 cmark on 🐧
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Apt-Get
+        run: sudo apt-get update && sudo apt-get install -y libcmark-dev libdevel-checklib-perl
+
+      - name: Build and Test
+        run: |
+          perl -V
+          [ -e Makefile ] && make realclean
+          perl Makefile.PL && make test TEST_VERBOSE=1
+
+  brew:
+    name: 📦 cmark on 🍎
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Brew Install
+        run: brew install cmark cpanm && cpanm -v --notest --no-man-pages Devel::CheckLib
+
+      - name: Build and Test
+        run: |
+          perl -V
+          [ -e Makefile ] && make realclean
+          perl Makefile.PL INC="-I$(brew --prefix)/include" LIBS="-L$(brew --prefix)/lib -lcmark"
+          make test TEST_VERBOSE=1

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
-/.build/
+/_build/
 /CommonMark-*/
-/CommonMark-*.tar.gz
+/blib
+/MANIFEST.bak
+/*META.*
+/Makefile*
+/pm_to_blib
+/CommonMark.bs
+/CommonMark.c
+/CommonMark.o

--- a/t/01_memory.t
+++ b/t/01_memory.t
@@ -7,6 +7,10 @@ BEGIN {
     use_ok('CommonMark');
 }
 
+diag sprintf "cmark compile time version: %s\ncmark runtime version: %s",
+    CommonMark->compile_time_version_string,
+    CommonMark->version_string;
+
 my $md = <<EOF;
 # Header
 

--- a/t/02_accessors.t
+++ b/t/02_accessors.t
@@ -1,5 +1,6 @@
 use strict;
 use warnings;
+use File::Spec::Functions qw(catfile);
 
 use Test::More tests => 28;
 
@@ -7,7 +8,7 @@ BEGIN {
     use_ok('CommonMark', ':all');
 }
 
-my $filename = 't/files/test.md';
+my $filename = catfile(qw(t files test.md));
 open(my $file, '<', $filename)
     or die("$filename: $!");
 my $doc = CommonMark->parse_file($file);

--- a/t/10_wrappers.t
+++ b/t/10_wrappers.t
@@ -1,5 +1,6 @@
 use strict;
 use warnings;
+use File::Spec::Functions qw(catfile);
 
 use Test::More tests => 11;
 
@@ -8,7 +9,7 @@ BEGIN {
 }
 
 {
-    my $filename = 't/files/test.md';
+    my $filename = catfile(qw(t files test.md));
     my $file;
 
     open($file, '<', $filename) or die("$filename: $!");


### PR DESCRIPTION
Create a GitHub workflow to test CommonMark against all supported versions of Perl and cmark on Linux, macOS, and Windows. Include tests for the system default Perl and and package-supplied cmark on Linux (Apt) and macOS (Homewbrew), as well. Each version of cmark has two steps: one for macOS and Linux using `build.sh`, and one for Windows using `build.ps1`. Just add new steps to test new versions.

Perls: 5.38, 5.36, 5.34, 5.32, 5.30, 5.28, 5.26, 5.24, 5.22, 5.20, 5.18, 5.16, 5.14, 5.12, 5.10, 5.8, macOS system, Linux System.

cmarks: 0.30.3, 0.29.0, 0.28.3, 0.27.1, 0.26.1, 0.25.2, 0.24.1, 0.20.0, apt-get, Homebrew.

All tests pass on Linux and macOS (as in [this run](https://github.com/theory/perl-commonmark/actions/runs/6147613844)), though the latter requires an updated version of ExtUtils::MakeMaker that includes Perl-Toolchain-Gang/ExtUtils-MakeMaker#402  so that it always finds cmark at runtime the same place it found it at compile time.

Windows tests do not currently pass at all: 5.32 (as in [this build](https://github.com/theory/perl-commonmark/actions/runs/6148615381/job/16682691309)) compiles but then `CommonMark->parse_file` dies without any error output in `t/02_accessors.t` and `t/10_wrappers.t` (I thought the issue might be the path, but use of File::Spec does not fix it). 5.38 (as [here](https://github.com/theory/perl-commonmark/actions/runs/6148336270/job/16681821527)) doesn't get past `perl Makefile.PL`, saying it cannot find the cmark library, even though INC and LIBS are set.

Windows tests do not currently pass at all: 5.32 compiles but then `make test` cannot find the cmark DLL; 5.38 doesn't get past `perl Makefile.PL`, saying it cannot find the cmark library, even though INC ane LIBS are set.

Also: update `.gitignore` to ignore additional files, and to specify root-level files and directories, and add some diagnostic output to `t/01_memory.t` to show the versions of cmark.
